### PR TITLE
BUG: Fix bug with x-tick positions

### DIFF
--- a/Keystats/NSDate+Utilities.h
+++ b/Keystats/NSDate+Utilities.h
@@ -25,6 +25,8 @@
 + (NSDate *) dateWithMinutesFromNow: (NSInteger) dMinutes;
 + (NSDate *) dateWithMinutesBeforeNow: (NSInteger) dMinutes;
 
++ (NSDate *) todayWithoutTime;
+
 // Short string utilities
 - (NSString *) stringWithDateStyle: (NSDateFormatterStyle) dateStyle timeStyle: (NSDateFormatterStyle) timeStyle;
 - (NSString *) stringWithFormat: (NSString *) format;

--- a/Keystats/NSDate+Utilities.m
+++ b/Keystats/NSDate+Utilities.m
@@ -81,6 +81,19 @@ static const unsigned componentFlags = (NSYearCalendarUnit| NSMonthCalendarUnit 
 	return newDate;		
 }
 
++ (NSDate *) todayWithoutTime{
+	// get today's date without hour/minute/second components
+	// http://stackoverflow.com/a/24345334/379593
+	NSCalendar *cal = [NSDate currentCalendar];
+	NSDateComponents *comps = [cal components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay fromDate:[NSDate date]];
+
+	[comps setHour:0];
+	[comps setMinute:0];
+	[comps setSecond:0];
+
+	return [cal dateFromComponents:comps];
+}
+
 #pragma mark - String Properties
 - (NSString *) stringWithFormat: (NSString *) format
 {

--- a/Keystats/YVBKeystrokesSummaryViewController.m
+++ b/Keystats/YVBKeystrokesSummaryViewController.m
@@ -97,7 +97,7 @@
 	// add an empty entry if today's date is not saved already,
 	// this way the plot updating routine will work seamlessly
 	if(indexOfToday == NSNotFound){
-		[__datesData addObject:[NSDate date]];
+		[__datesData addObject:[NSDate todayWithoutTime]];
 		[__keystrokesData addObject:[NSNumber numberWithLongLong:0]];
 
 		// be consistent and remove the extra object
@@ -138,6 +138,20 @@
 
 	// we use ceil here to create a number with a small "padding"
 	maxKeystrokes = ceil(maxKeystrokes + (0.11*maxKeystrokes));
+
+	// we set the tick locations manually because:
+	//  * we've found that daylight savings screw the location of each date
+	//  * cleaning date objects for them to be comparable didn't prove very reliable
+	//  * we can guarantee that ticks will be located at the center of every bar
+	//  * this is the cleanest way to guarantee the previous point
+	NSMutableSet *dateTicks = [[NSMutableSet alloc] init];
+	NSTimeInterval interval = 0;
+	for (NSUInteger t = 0; t < [__datesData count]; t++) {
+		// for more information on this rationale see:
+		// numberForPlot:field:recordIndex:
+		interval = [[__datesData objectAtIndex:t] timeIntervalSinceDate:refDate];
+		[dateTicks addObject:[NSDecimalNumber numberWithDouble:interval]];
+	}
 
 	// __knownMax sets when we have to reload the full plot
 	__knownMax = maxKeystrokes;
@@ -241,7 +255,8 @@
 	[xBottom setPlotSpace:plotSpace];
 	[xBottom setMajorTickLineStyle:majorGridLineStyle];
 	[xBottom setMinorTickLineStyle:minorGridLineStyle];
-	[xBottom setMajorIntervalLength:CPTDecimalFromDouble(padding)];
+	[xBottom setLabelingPolicy:CPTAxisLabelingPolicyLocationsProvided];
+	[xBottom setMajorTickLocations:dateTicks];
 	[xBottom setOrthogonalCoordinateDecimal:CPTDecimalFromFloat(0)];
 	[xBottom setCoordinate:CPTCoordinateX];
 	[xBottom setAxisLineStyle:majorGridLineStyle];


### PR DESCRIPTION
We had to move from a fixed-interval labeling policy to a
location-provided one. The main reason is because the location of each
bar varies depending on what time-zone (or whatever other voodoo) the
data was collected at, so to be perfectly accurate: ticks are now
located at the same position where the bars are.

I first encountered this problem when we went through daylight savings a
few days ago.